### PR TITLE
CI/CD: Publish release artifacts to GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            artifact: runner-linux-x86_64.tar.gz
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: runner-linux-aarch64.tar.gz
+            use_cross: true
+          - os: macos-13
+            target: x86_64-apple-darwin
+            artifact: runner-macos-x86_64.tar.gz
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            artifact: runner-macos-aarch64.tar.gz
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            artifact: runner-windows-x86_64.zip
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.use_cross == true
+        uses: taiki-e/install-action@cross
+
+      - name: Build
+        shell: bash
+        env:
+          CARGO_PROFILE_RELEASE_STRIP: symbols
+        run: |
+          if [ "${{ matrix.use_cross }}" = "true" ]; then
+            cross build --release --target ${{ matrix.target }}
+          else
+            cargo build --release --target ${{ matrix.target }}
+          fi
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: tar czf ${{ matrix.artifact }} -C target/${{ matrix.target }}/release runner
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path target\${{ matrix.target }}\release\runner.exe -DestinationPath ${{ matrix.artifact }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: ${{ matrix.artifact }}
+
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            runner-linux-x86_64.tar.gz
+            runner-linux-aarch64.tar.gz
+            runner-macos-x86_64.tar.gz
+            runner-macos-aarch64.tar.gz
+            runner-windows-x86_64.zip


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` that triggers on `v*` tag pushes
- Builds and packages binaries for all 5 target platforms using a matrix strategy
- Creates a GitHub Release with auto-generated notes and uploads all artifacts

## Targets

| Platform | OS | Tool |
|---|---|---|
| Linux x86_64 | ubuntu-latest | cargo |
| Linux aarch64 | ubuntu-latest | cross |
| macOS x86_64 | macos-13 | cargo |
| macOS aarch64 | macos-latest | cargo |
| Windows x86_64 | windows-latest | cargo |

Unix artifacts are packaged as `.tar.gz`; Windows as `.zip`. Binaries are stripped via `CARGO_PROFILE_RELEASE_STRIP=symbols`.

Closes #1

## Test plan

- [ ] Push a `v*` tag and verify the workflow triggers
- [ ] Confirm all 5 build jobs succeed and produce artifacts
- [ ] Verify the GitHub Release is created with all 5 artifacts attached and release notes generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)