### PR TITLE
Add `editor` query param to worktree:// deep links

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,5 @@ pub mod opener;
 pub mod workspace;
 
 pub use config::Config;
-pub use issue::IssueRef;
+pub use issue::{DeepLinkOptions, IssueRef};
 pub use workspace::Workspace;


### PR DESCRIPTION
## Summary

- Adds a `DeepLinkOptions` struct to `issue.rs` carrying an optional `editor` field
- Extracts the `editor` query param in `parse_worktree_url` alongside existing params
- Adds `IssueRef::parse_with_options` for callers that need both the issue ref and deep-link options
- Updates `cmd_open` to use the deep-link editor override (takes precedence over `config.editor.command`)
- Adds `resolve_editor_command` to map symbolic names (`cursor`, `code`, `zed`, `subl`, `nvim`, `vim`) to launch commands; unknown values are passed through as raw command strings

Closes #2

## Test plan

- [x] `test_parse_worktree_url_with_editor_symbolic` — symbolic name is extracted verbatim
- [x] `test_parse_worktree_url_with_editor_raw_command` — percent-encoded raw command is decoded correctly
- [x] `test_parse_with_options_no_editor` — absent param yields `None`
- [x] `test_parse_with_options_non_deep_link` — non-deep-link refs return empty options
- [x] All 9 tests pass, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)