### PR TITLE
Rename `daemon` subcommand to `scheme`, remove `install` action

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod config;
-pub mod daemon;
+pub mod scheme;
 pub mod issue;
 pub mod opener;
 pub mod workspace;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 
 use worktree_io::{
     config::Config,
-    daemon,
+    scheme,
     issue::IssueRef,
     opener,
     workspace::Workspace,
@@ -40,9 +40,9 @@ enum Commands {
     },
 
     /// Manage the worktree:// URL scheme handler
-    Daemon {
+    Scheme {
         #[command(subcommand)]
-        action: DaemonAction,
+        action: SchemeAction,
     },
 
     /// Run first-time setup: detect editor, write config, register URL scheme
@@ -69,9 +69,7 @@ enum ConfigAction {
 }
 
 #[derive(Subcommand)]
-enum DaemonAction {
-    /// Register the worktree:// URL scheme handler
-    Install,
+enum SchemeAction {
     /// Unregister the worktree:// URL scheme handler
     Uninstall,
     /// Check whether the URL scheme handler is registered
@@ -88,7 +86,7 @@ fn main() -> Result<()> {
 
         Commands::Config { action } => cmd_config(action)?,
 
-        Commands::Daemon { action } => cmd_daemon(action)?,
+        Commands::Scheme { action } => cmd_scheme(action)?,
 
         Commands::Setup => cmd_setup()?,
     }
@@ -179,11 +177,10 @@ fn cmd_config(action: ConfigAction) -> Result<()> {
     Ok(())
 }
 
-fn cmd_daemon(action: DaemonAction) -> Result<()> {
+fn cmd_scheme(action: SchemeAction) -> Result<()> {
     match action {
-        DaemonAction::Install => daemon::install()?,
-        DaemonAction::Uninstall => daemon::uninstall()?,
-        DaemonAction::Status => println!("{}", daemon::status()?),
+        SchemeAction::Uninstall => scheme::uninstall()?,
+        SchemeAction::Status => println!("{}", scheme::status()?),
     }
     Ok(())
 }
@@ -208,7 +205,7 @@ fn cmd_setup() -> Result<()> {
     }
 
     // Register URL scheme handler (warn but don't abort on failure)
-    match daemon::install() {
+    match scheme::install() {
         Ok(()) => {}
         Err(e) => eprintln!("Warning: could not register URL scheme handler: {e}"),
     }

--- a/src/scheme.rs
+++ b/src/scheme.rs
@@ -1,12 +1,12 @@
 use anyhow::{bail, Context, Result};
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum DaemonStatus {
+pub enum SchemeStatus {
     Installed { path: String },
     NotInstalled,
 }
 
-impl std::fmt::Display for DaemonStatus {
+impl std::fmt::Display for SchemeStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Installed { path } => write!(f, "Installed at {path}"),
@@ -23,7 +23,7 @@ pub fn uninstall() -> Result<()> {
     platform_uninstall()
 }
 
-pub fn status() -> Result<DaemonStatus> {
+pub fn status() -> Result<SchemeStatus> {
     platform_status()
 }
 
@@ -161,14 +161,14 @@ fn platform_uninstall() -> Result<()> {
 }
 
 #[cfg(target_os = "macos")]
-fn platform_status() -> Result<DaemonStatus> {
+fn platform_status() -> Result<SchemeStatus> {
     let app = app_dir();
     if app.join("Contents").join("Info.plist").exists() {
-        Ok(DaemonStatus::Installed {
+        Ok(SchemeStatus::Installed {
             path: app.display().to_string(),
         })
     } else {
-        Ok(DaemonStatus::NotInstalled)
+        Ok(SchemeStatus::NotInstalled)
     }
 }
 
@@ -229,14 +229,14 @@ fn platform_uninstall() -> Result<()> {
 }
 
 #[cfg(target_os = "linux")]
-fn platform_status() -> Result<DaemonStatus> {
+fn platform_status() -> Result<SchemeStatus> {
     let path = desktop_file();
     if path.exists() {
-        Ok(DaemonStatus::Installed {
+        Ok(SchemeStatus::Installed {
             path: path.display().to_string(),
         })
     } else {
-        Ok(DaemonStatus::NotInstalled)
+        Ok(SchemeStatus::NotInstalled)
     }
 }
 
@@ -307,7 +307,7 @@ fn platform_uninstall() -> Result<()> {
 }
 
 #[cfg(target_os = "windows")]
-fn platform_status() -> Result<DaemonStatus> {
+fn platform_status() -> Result<SchemeStatus> {
     use std::process::Command;
 
     let output = Command::new("reg")
@@ -316,11 +316,11 @@ fn platform_status() -> Result<DaemonStatus> {
         .context("Failed to query registry")?;
 
     if output.status.success() {
-        Ok(DaemonStatus::Installed {
+        Ok(SchemeStatus::Installed {
             path: r"HKCU\Software\Classes\worktree".to_string(),
         })
     } else {
-        Ok(DaemonStatus::NotInstalled)
+        Ok(SchemeStatus::NotInstalled)
     }
 }
 
@@ -337,6 +337,6 @@ fn platform_uninstall() -> Result<()> {
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-fn platform_status() -> Result<DaemonStatus> {
-    Ok(DaemonStatus::NotInstalled)
+fn platform_status() -> Result<SchemeStatus> {
+    Ok(SchemeStatus::NotInstalled)
 }


### PR DESCRIPTION
## Summary

- Renames `worktree daemon` to `worktree scheme` — the subcommand manages URL scheme handler registration, not a background daemon process
- Removes the `install` action from the subcommand; `worktree setup` already handles registration
- Keeps `uninstall` and `status`, which have no equivalent elsewhere in the CLI
- Renames internal module `daemon` → `scheme` and `DaemonStatus` → `SchemeStatus` for consistency

Closes #fe906159-dadd-44cc-bdaf-7bd5c24a72aa

## Test plan

- [ ] `worktree scheme --help` shows `uninstall` and `status` subcommands (no `install`)
- [ ] `worktree scheme status` reports handler registration state
- [ ] `worktree scheme uninstall` removes the handler
- [ ] `worktree setup` still registers the handler (calls `scheme::install()` internally)
- [ ] `worktree daemon` (old name) is no longer a valid subcommand

🤖 Generated with [Claude Code](https://claude.com/claude-code)