### PR TITLE
Add version subcommand and --version/-V flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use commands::scheme::{cmd_scheme, SchemeAction};
 use commands::setup::cmd_setup;
 
 #[derive(Parser)]
-#[command(name = "worktree", about = "Open GitHub issues as git worktree workspaces")]
+#[command(name = "worktree", about = "Open GitHub issues as git worktree workspaces", version)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -45,6 +45,9 @@ enum Commands {
 
     /// Run first-time setup: detect editor, write config, register URL scheme
     Setup,
+
+    /// Print the current version
+    Version,
 }
 
 fn main() -> Result<()> {
@@ -55,6 +58,7 @@ fn main() -> Result<()> {
         Commands::Config { action } => cmd_config(action)?,
         Commands::Scheme { action } => cmd_scheme(action)?,
         Commands::Setup => cmd_setup()?,
+        Commands::Version => println!("{}", env!("CARGO_PKG_VERSION")),
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- Adds a `version` subcommand (`runner version`) that prints the current crate version to stdout
- Enables clap's built-in `--version` / `-V` flag via `#[command(version)]` on the `Cli` struct
- Version is sourced from `env!("CARGO_PKG_VERSION")` — no hardcoding

Closes #8

## Test plan

- [ ] `runner version` prints `0.6.1`
- [ ] `runner --version` prints `worktree 0.6.1`
- [ ] `runner -V` prints `worktree 0.6.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)