### PR TITLE
Add cargo-husky pre-push hook to enforce 200-line file limit

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+MAX_LINES=200
+FAILED=0
+
+for file in $(find src -name "*.rs"); do
+    count=$(wc -l < "$file")
+    if [ "$count" -gt "$MAX_LINES" ]; then
+        echo "error: $file has $count lines (limit is $MAX_LINES)"
+        FAILED=1
+    fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "Push blocked: one or more source files exceed the $MAX_LINES line limit."
+    exit 1
+fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -669,6 +675,7 @@ name = "worktree-io"
 version = "0.6.1"
 dependencies = [
  "anyhow",
+ "cargo-husky",
  "clap",
  "dirs",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ path = "src/lib.rs"
 name = "worktree"
 path = "src/main.rs"
 
+[dev-dependencies]
+cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
+
 [dependencies]
 clap    = { version = "4", features = ["derive"] }
 serde   = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Adds `cargo-husky` as a dev dependency (with `user-hooks` feature, no default features)
- Adds `.cargo-husky/hooks/pre-push` script that iterates over all `*.rs` files in `src/`, counts lines with `wc -l`, and fails with a clear error if any file exceeds 200 lines
- Hook is installed automatically when running `cargo test`

Closes #7

## Test plan

- [ ] Clone fresh, run `cargo test` — verify `.git/hooks/pre-push` is installed
- [ ] Create a `.rs` file with >200 lines and attempt `git push` — verify push is blocked with a clear error message
- [ ] Confirm push succeeds when all files are within the 200-line limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)