### PR TITLE
Pre-push: add cargo build check

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+echo "Running cargo build…"
+if ! cargo build 2>&1; then
+    echo "Push blocked: cargo build failed. Fix the build errors before pushing."
+    exit 1
+fi
+
 MAX_LINES=100
 FAILED=0
 


### PR DESCRIPTION
## Summary

- Adds `cargo build` step to the `.cargo-husky` pre-push hook
- Blocks the push with a clear error message if the build fails
- Runs before the line-count check for fast feedback

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)