### PR TITLE
Close issue #12: Pre-commit cargo clippy lint check

### DIFF
--- a/.cargo-husky/hooks/pre-commit
+++ b/.cargo-husky/hooks/pre-commit
@@ -11,3 +11,9 @@ if [ $? -ne 0 ]; then
     echo "Run \`cargo fmt\` to fix formatting."
     exit 1
 fi
+
+echo "Running cargo clippy…"
+if ! cargo clippy --all-targets --all-features -- -D warnings 2>&1; then
+    echo "Commit blocked: cargo clippy reported warnings or errors. Fix them before committing."
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `cargo clippy --all-targets --all-features -- -D warnings` step to the pre-commit hook
- Blocks commits if clippy reports any warnings or errors
- Covers tests and examples via `--all-targets --all-features`

## Test plan

- [ ] Verify pre-commit hook runs clippy after fmt check
- [ ] Confirm a commit with clippy warnings is blocked
- [ ] Confirm a clean commit proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)