### PR TITLE
fix(config): restore website link comment at top of saved config

### DIFF
--- a/src/config/ser.rs
+++ b/src/config/ser.rs
@@ -23,6 +23,9 @@ impl Config {
     pub fn to_toml_with_comments(&self) -> String {
         let mut out = String::new();
 
+        // Website header comment
+        out.push_str("# runner \u{2014} https://worktree.io\n\n");
+
         // [editor] ------------------------------------------------------------
         out.push_str("# Editor configuration.\n");
         out.push_str("[editor]\n");

--- a/src/config/ser_tests.rs
+++ b/src/config/ser_tests.rs
@@ -1,6 +1,12 @@
 use super::*;
 
 #[test]
+fn test_website_comment_is_first_line() {
+    let s = Config::default().to_toml_with_comments();
+    assert!(s.starts_with("# runner \u{2014} https://worktree.io\n"));
+}
+
+#[test]
 fn test_default_output_structure() {
     let s = Config::default().to_toml_with_comments();
     assert!(s.contains("[editor]"));


### PR DESCRIPTION
## Summary

- The `# runner — https://worktree.io` header comment was accidentally lost during the issue-18 conflict resolution (`9c54706`)
- Restores it as the first line emitted by `Config::to_toml_with_comments()`
- Adds a `test_website_comment_is_first_line` unit test to prevent regression

## Test plan

- [x] `cargo test config::ser` — all 7 tests pass
- [x] Clippy and coverage checks pass

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)