### PR TITLE
fix: preserve multiline hook scripts as TOML triple-quoted strings

### DIFF
--- a/src/config/ser.rs
+++ b/src/config/ser.rs
@@ -3,11 +3,17 @@ use std::fmt::Write as _;
 use super::Config;
 
 /// Wrap a string value in TOML basic-string quotes, escaping special characters.
+///
+/// When the value contains newlines, a TOML multiline basic string (`"""..."""`) is
+/// used so that hook scripts remain human-readable in the config file.
 fn toml_quoted(s: &str) -> String {
+    if s.contains('\n') {
+        let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+        return format!("\"\"\"\n{escaped}\"\"\"");
+    }
     let escaped = s
         .replace('\\', "\\\\")
         .replace('"', "\\\"")
-        .replace('\n', "\\n")
         .replace('\r', "\\r")
         .replace('\t', "\\t");
     format!("\"{escaped}\"")

--- a/src/config/ser_tests.rs
+++ b/src/config/ser_tests.rs
@@ -80,3 +80,25 @@ fn test_escapes_special_chars() {
         Some(r#"cmd "with" quotes"#)
     );
 }
+
+#[test]
+fn test_multiline_hook_uses_triple_quotes() {
+    let script = "#!/usr/bin/env bash\necho \"hello\"\n";
+    let mut c = Config::default();
+    c.hooks.post_open = Some(script.into());
+    let s = c.to_toml_with_comments();
+    assert!(s.contains("\"post:open\" = \"\"\"\n"), "expected multiline basic string");
+    assert!(!s.contains("\\n"), "newlines must not be escaped as \\n");
+}
+
+#[test]
+fn test_multiline_hook_round_trips() {
+    let script = "#!/usr/bin/env bash\necho \"Worktree ready\"\n";
+    let mut c = Config::default();
+    c.hooks.pre_open = Some(script.into());
+    c.hooks.post_open = Some(script.into());
+    let s = c.to_toml_with_comments();
+    let parsed: Config = toml::from_str(&s).unwrap();
+    assert_eq!(parsed.hooks.pre_open.as_deref(), Some(script));
+    assert_eq!(parsed.hooks.post_open.as_deref(), Some(script));
+}


### PR DESCRIPTION
## Summary

- `toml_quoted` in `src/config/ser.rs` now detects values containing `\n` and emits a TOML multiline basic string (`"""..."""`) instead of escaping newlines as `\\n`
- Hook scripts remain human-readable and editable after `config.save()` is called
- Single-line values are unchanged

## Test plan

- [ ] `test_multiline_hook_uses_triple_quotes` — verifies multiline output uses `"""` and contains no `\n` escapes
- [ ] `test_multiline_hook_round_trips` — verifies the TOML parses back to the original script string
- [ ] All 84 existing tests continue to pass

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)