### PR TITLE
feat: Azure DevOps work item support

### DIFF
--- a/src/commands/open/mod.rs
+++ b/src/commands/open/mod.rs
@@ -72,6 +72,9 @@ fn build_hook_context(issue: &IssueRef, worktree_path: &std::path::Path) -> Hook
             number,
         } => (owner.clone(), repo.clone(), number.to_string()),
         IssueRef::Linear { owner, repo, id } => (owner.clone(), repo.clone(), id.clone()),
+        IssueRef::AzureDevOps { org, project, repo, id } => {
+            (format!("{org}/{project}"), repo.clone(), id.to_string())
+        }
         IssueRef::Local {
             project_path,
             display_number,

--- a/src/commands/open/tests.rs
+++ b/src/commands/open/tests.rs
@@ -11,3 +11,18 @@ fn test_build_hook_ctx_linear() {
     assert_eq!(ctx.issue, "X-1");
     assert_eq!(ctx.branch, "linear-X-1");
 }
+
+#[test]
+fn test_build_hook_ctx_azure_devops() {
+    let issue = IssueRef::AzureDevOps {
+        org: "myorg".into(),
+        project: "myproject".into(),
+        repo: "myrepo".into(),
+        id: 42,
+    };
+    let ctx = build_hook_context(&issue, std::path::Path::new("/tmp"));
+    assert_eq!(ctx.owner, "myorg/myproject");
+    assert_eq!(ctx.repo, "myrepo");
+    assert_eq!(ctx.issue, "42");
+    assert_eq!(ctx.branch, "workitem-42");
+}

--- a/src/issue/azure_tests.rs
+++ b/src/issue/azure_tests.rs
@@ -1,0 +1,144 @@
+use super::*;
+
+#[test]
+fn test_parse_azure_devops_url() {
+    let r = IssueRef::parse("https://dev.azure.com/myorg/myproject/_workitems/edit/42").unwrap();
+    assert_eq!(
+        r,
+        IssueRef::AzureDevOps {
+            org: "myorg".into(),
+            project: "myproject".into(),
+            repo: "myproject".into(),
+            id: 42,
+        }
+    );
+}
+
+#[test]
+fn test_parse_azure_devops_url_invalid_id() {
+    let err =
+        IssueRef::parse("https://dev.azure.com/myorg/myproject/_workitems/edit/abc").unwrap_err();
+    assert!(err.to_string().contains("Invalid work item ID"));
+}
+
+#[test]
+fn test_parse_azure_devops_url_wrong_format() {
+    let err = IssueRef::parse("https://dev.azure.com/myorg/myproject/_boards/board").unwrap_err();
+    assert!(err.to_string().contains("Expected Azure DevOps work item URL"));
+}
+
+#[test]
+fn test_parse_azure_devops_shorthand() {
+    let r = IssueRef::parse("myorg/myproject/myrepo!42").unwrap();
+    assert_eq!(
+        r,
+        IssueRef::AzureDevOps {
+            org: "myorg".into(),
+            project: "myproject".into(),
+            repo: "myrepo".into(),
+            id: 42,
+        }
+    );
+}
+
+#[test]
+fn test_parse_azure_devops_shorthand_invalid_id() {
+    let err = IssueRef::parse("myorg/myproject/myrepo!abc").unwrap_err();
+    assert!(err.to_string().contains("Invalid work item ID"));
+}
+
+#[test]
+fn test_parse_azure_devops_shorthand_missing_parts() {
+    let err = IssueRef::parse("myorg/myproject!42").unwrap_err();
+    assert!(err.to_string().contains("Invalid Azure DevOps shorthand"));
+}
+
+#[test]
+fn test_parse_azure_devops_worktree_url() {
+    let r =
+        IssueRef::parse("worktree://open?org=myorg&project=myproject&ado_repo=myrepo&work_item_id=42")
+            .unwrap();
+    assert_eq!(
+        r,
+        IssueRef::AzureDevOps {
+            org: "myorg".into(),
+            project: "myproject".into(),
+            repo: "myrepo".into(),
+            id: 42,
+        }
+    );
+}
+
+#[test]
+fn test_parse_azure_devops_worktree_url_defaults_repo_to_project() {
+    let r = IssueRef::parse("worktree://open?org=myorg&project=myproject&work_item_id=42").unwrap();
+    assert_eq!(
+        r,
+        IssueRef::AzureDevOps {
+            org: "myorg".into(),
+            project: "myproject".into(),
+            repo: "myproject".into(),
+            id: 42,
+        }
+    );
+}
+
+#[test]
+fn test_parse_azure_devops_worktree_url_with_editor() {
+    let (r, opts) = IssueRef::parse_with_options(
+        "worktree://open?org=myorg&project=myproject&work_item_id=42&editor=cursor",
+    )
+    .unwrap();
+    assert_eq!(
+        r,
+        IssueRef::AzureDevOps {
+            org: "myorg".into(),
+            project: "myproject".into(),
+            repo: "myproject".into(),
+            id: 42,
+        }
+    );
+    assert_eq!(opts.editor.as_deref(), Some("cursor"));
+}
+
+#[test]
+fn test_azure_devops_workspace_dir_name() {
+    let r = IssueRef::AzureDevOps {
+        org: "myorg".into(),
+        project: "myproject".into(),
+        repo: "myrepo".into(),
+        id: 42,
+    };
+    assert_eq!(r.workspace_dir_name(), "workitem-42");
+    assert_eq!(r.branch_name(), "workitem-42");
+}
+
+#[test]
+fn test_azure_devops_clone_url() {
+    let r = IssueRef::AzureDevOps {
+        org: "myorg".into(),
+        project: "myproject".into(),
+        repo: "myrepo".into(),
+        id: 42,
+    };
+    assert_eq!(
+        r.clone_url(),
+        "https://dev.azure.com/myorg/myproject/_git/myrepo"
+    );
+}
+
+#[test]
+fn test_azure_devops_paths() {
+    let r = IssueRef::AzureDevOps {
+        org: "myorg".into(),
+        project: "myproject".into(),
+        repo: "myrepo".into(),
+        id: 42,
+    };
+    assert!(r
+        .bare_clone_path()
+        .ends_with("worktrees/azuredevops/myorg/myproject/myrepo"));
+    assert!(r
+        .temp_path()
+        .ends_with("worktrees/azuredevops/myorg/myproject/myrepo/workitem-42"));
+}

--- a/src/issue/mod.rs
+++ b/src/issue/mod.rs
@@ -10,6 +10,9 @@ mod tests;
 mod linear_tests;
 
 #[cfg(test)]
+mod azure_tests;
+
+#[cfg(test)]
 mod uuid_tests;
 
 #[cfg(test)]
@@ -48,6 +51,17 @@ pub enum IssueRef {
         /// Linear issue UUID.
         id: String,
     },
+    /// An Azure DevOps work item paired with an Azure Repos git repository.
+    AzureDevOps {
+        /// Azure DevOps organization name.
+        org: String,
+        /// Azure DevOps project name.
+        project: String,
+        /// Azure Repos git repository name.
+        repo: String,
+        /// Work item ID.
+        id: u64,
+    },
     /// A local Centy issue — the repository itself is the source, no remote clone needed.
     Local {
         /// Absolute path to the local project repository.
@@ -64,6 +78,7 @@ impl IssueRef {
         match self {
             Self::GitHub { number, .. } => format!("issue-{number}"),
             Self::Linear { id, .. } => format!("linear-{id}"),
+            Self::AzureDevOps { id, .. } => format!("workitem-{id}"),
             Self::Local { display_number, .. } => format!("issue-{display_number}"),
         }
     }
@@ -84,6 +99,9 @@ impl IssueRef {
         match self {
             Self::GitHub { owner, repo, .. } | Self::Linear { owner, repo, .. } => {
                 format!("https://github.com/{owner}/{repo}.git")
+            }
+            Self::AzureDevOps { org, project, repo, .. } => {
+                format!("https://dev.azure.com/{org}/{project}/_git/{repo}")
             }
             Self::Local { .. } => {
                 unreachable!("clone_url is never called for IssueRef::Local")

--- a/src/issue/parse/mod.rs
+++ b/src/issue/parse/mod.rs
@@ -31,6 +31,10 @@ impl IssueRef {
             return parse_github_url(s);
         }
 
+        if s.starts_with("https://dev.azure.com") || s.starts_with("http://dev.azure.com") {
+            return parse_azure_devops_url(s);
+        }
+
         if let Some(result) = shorthand::try_parse_shorthand(s) {
             return result;
         }
@@ -39,10 +43,13 @@ impl IssueRef {
             "Could not parse issue reference: {s:?}\n\
              Supported formats:\n\
              - https://github.com/owner/repo/issues/42\n\
+             - https://dev.azure.com/org/project/_workitems/edit/42\n\
              - worktree://open?owner=owner&repo=repo&issue=42\n\
              - worktree://open?owner=owner&repo=repo&linear_id=<uuid>\n\
+             - worktree://open?org=org&project=project&repo=repo&work_item_id=42\n\
              - owner/repo#42\n\
-             - owner/repo@<linear-uuid>"
+             - owner/repo@<linear-uuid>\n\
+             - org/project/repo!42"
         )
     }
 
@@ -59,6 +66,43 @@ impl IssueRef {
         }
         Ok((Self::parse(s)?, DeepLinkOptions::default()))
     }
+}
+
+/// Parse an Azure DevOps work item URL.
+///
+/// Expected format: `https://dev.azure.com/{org}/{project}/_workitems/edit/{id}`
+///
+/// Since the URL does not include the git repository name, the project name is
+/// used as the repository name by default.
+pub(super) fn parse_azure_devops_url(s: &str) -> Result<IssueRef> {
+    let url = Url::parse(s).with_context(|| format!("Invalid URL: {s}"))?;
+
+    let segments: Vec<&str> = url
+        .path_segments()
+        .context("URL has no path")?
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // Expected: [org, project, "_workitems", "edit", id]
+    if segments.len() < 5 || segments[2] != "_workitems" || segments[3] != "edit" {
+        bail!(
+            "Expected Azure DevOps work item URL like \
+             https://dev.azure.com/org/project/_workitems/edit/42, got: {s}"
+        );
+    }
+
+    let org = segments[0].to_string();
+    let project = segments[1].to_string();
+    let id = segments[4]
+        .parse::<u64>()
+        .with_context(|| format!("Invalid work item ID in URL: {}", segments[4]))?;
+
+    Ok(IssueRef::AzureDevOps {
+        repo: project.clone(),
+        org,
+        project,
+        id,
+    })
 }
 
 pub(super) fn parse_github_url(s: &str) -> Result<IssueRef> {

--- a/src/issue/parse/shorthand.rs
+++ b/src/issue/parse/shorthand.rs
@@ -3,6 +3,28 @@ use anyhow::Result;
 use crate::issue::IssueRef;
 
 pub(super) fn try_parse_shorthand(s: &str) -> Option<Result<IssueRef>> {
+    // Azure DevOps: org/project/repo!42
+    if let Some((path_part, id_str)) = s.split_once('!') {
+        let mut parts = path_part.splitn(3, '/');
+        let org = parts.next().unwrap_or("");
+        let project = parts.next().unwrap_or("");
+        let repo = parts.next().unwrap_or("");
+        if org.is_empty() || project.is_empty() || repo.is_empty() {
+            return Some(Err(anyhow::anyhow!("Invalid Azure DevOps shorthand format: {s}")));
+        }
+        let Ok(id) = id_str.parse::<u64>() else {
+            return Some(Err(anyhow::anyhow!(
+                "Invalid work item ID in shorthand: {id_str}"
+            )));
+        };
+        return Some(Ok(IssueRef::AzureDevOps {
+            org: org.to_string(),
+            project: project.to_string(),
+            repo: repo.to_string(),
+            id,
+        }));
+    }
+
     if let Some((repo_part, id)) = s.split_once('@') {
         let (owner, repo) = repo_part.split_once('/')?;
         if owner.is_empty() || repo.is_empty() {

--- a/src/issue/parse/worktree_url.rs
+++ b/src/issue/parse/worktree_url.rs
@@ -11,6 +11,10 @@ pub(super) fn parse_worktree_url(s: &str) -> Result<(IssueRef, DeepLinkOptions)>
     let mut linear_id = None;
     let mut url_param = None;
     let mut editor = None;
+    let mut ado_org = None;
+    let mut ado_project = None;
+    let mut ado_repo = None;
+    let mut ado_work_item_id = None;
 
     for (key, val) in url.query_pairs() {
         match key.as_ref() {
@@ -33,6 +37,15 @@ pub(super) fn parse_worktree_url(s: &str) -> Result<(IssueRef, DeepLinkOptions)>
                 url_param = Some(val.into_owned());
             }
             "editor" => editor = Some(val.into_owned()),
+            "org" => ado_org = Some(val.into_owned()),
+            "project" => ado_project = Some(val.into_owned()),
+            "ado_repo" => ado_repo = Some(val.into_owned()),
+            "work_item_id" => {
+                ado_work_item_id = Some(
+                    val.parse::<u64>()
+                        .with_context(|| format!("Invalid work item ID: {val}"))?,
+                );
+            }
             _ => {}
         }
     }
@@ -50,6 +63,16 @@ pub(super) fn parse_worktree_url(s: &str) -> Result<(IssueRef, DeepLinkOptions)>
                 repo: repo.context("Missing 'repo' query param")?,
                 id,
             },
+            opts,
+        ));
+    }
+
+    if let Some(id) = ado_work_item_id {
+        let org = ado_org.context("Missing 'org' query param")?;
+        let project = ado_project.context("Missing 'project' query param")?;
+        let repo = ado_repo.unwrap_or_else(|| project.clone());
+        return Ok((
+            IssueRef::AzureDevOps { org, project, repo, id },
             opts,
         ));
     }

--- a/src/issue/paths.rs
+++ b/src/issue/paths.rs
@@ -26,6 +26,13 @@ impl IssueRef {
                 .join("github")
                 .join(owner)
                 .join(repo),
+            Self::AzureDevOps { org, project, repo, .. } => dirs::home_dir()
+                .expect("could not determine home directory")
+                .join("worktrees")
+                .join("azuredevops")
+                .join(org)
+                .join(project)
+                .join(repo),
             Self::Local { project_path, .. } => {
                 let project_name = project_path
                     .file_name()


### PR DESCRIPTION
## Summary

- Adds `IssueRef::AzureDevOps` variant with `org`, `project`, `repo`, and `id` fields
- Supports three input formats: Azure DevOps work item URLs, `org/project/repo!42` shorthand, and `worktree://` deep links with `work_item_id` param
- Worktrees stored at `~/worktrees/azuredevops/{org}/{project}/{repo}/workitem-{id}`
- Clone URL targets Azure Repos: `https://dev.azure.com/{org}/{project}/_git/{repo}`
- When parsing bare work item URLs (which lack a repo name), defaults the repo to the project name; the `ado_repo` deep link param allows an explicit override

## Test plan

- [x] `test_parse_azure_devops_url` — URL parsing happy path
- [x] `test_parse_azure_devops_url_invalid_id` — non-numeric ID returns error
- [x] `test_parse_azure_devops_url_wrong_format` — wrong URL path returns error
- [x] `test_parse_azure_devops_shorthand` — `org/project/repo!42` shorthand
- [x] `test_parse_azure_devops_shorthand_invalid_id` — non-numeric shorthand ID
- [x] `test_parse_azure_devops_shorthand_missing_parts` — too-few segments
- [x] `test_parse_azure_devops_worktree_url` — deep link with explicit `ado_repo`
- [x] `test_parse_azure_devops_worktree_url_defaults_repo_to_project` — deep link without `ado_repo`
- [x] `test_parse_azure_devops_worktree_url_with_editor` — deep link with `editor` param
- [x] `test_azure_devops_workspace_dir_name` — `workitem-{id}` dir/branch name
- [x] `test_azure_devops_clone_url` — Azure Repos clone URL
- [x] `test_azure_devops_paths` — correct bare clone and temp paths
- [x] `test_build_hook_ctx_azure_devops` — hook context fields

All 136 tests pass (`cargo test`).

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)