### PR TITLE
fix: ad-hoc codesign and LaunchAgent for URL scheme persistence (issue #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Ad-hoc code-sign `WorktreeRunner.app` after `osacompile` so Gatekeeper does not quarantine or evict the unsigned bundle ([#22](https://github.com/worktree-io/runner/issues/22))
+- Install a `~/Library/LaunchAgents/io.worktree.runner.plist` that re-registers the `worktree://` URL scheme via `lsregister` at login, restoring the handler if Launch Services forgets it after a reboot ([#22](https://github.com/worktree-io/runner/issues/22))
+- `worktree scheme uninstall` now also removes the LaunchAgent plist ([#22](https://github.com/worktree-io/runner/issues/22))
+
 ## [0.9.0] - 2026-02-23
 
 ### Fixed

--- a/src/scheme/macos/install.rs
+++ b/src/scheme/macos/install.rs
@@ -59,8 +59,16 @@ pub fn install() -> Result<()> {
         "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string worktree",
         &plist,
     )?;
-    let lsregister = "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/\
-        LaunchServices.framework/Versions/A/Support/lsregister";
+    // Ad-hoc sign the bundle so Gatekeeper does not quarantine or evict it.
+    let status = Command::new("codesign")
+        .args(["--sign", "-", "--force", "--deep"])
+        .arg(&app)
+        .status()
+        .context("Failed to run codesign")?;
+    if !status.success() {
+        bail!("codesign failed");
+    }
+    let lsregister = super::LSREGISTER;
     let status = Command::new(lsregister)
         .arg("-f")
         .arg(&app)
@@ -69,9 +77,46 @@ pub fn install() -> Result<()> {
     if !status.success() {
         bail!("lsregister failed");
     }
+    install_launch_agent(&app)?;
     println!("Installed WorktreeRunner.app at {}", app.display());
     println!("The worktree:// URL scheme is now registered.");
     Ok(())
+}
+
+fn install_launch_agent(app: &std::path::Path) -> Result<()> {
+    let agents_dir = dirs::home_dir()
+        .context("Failed to get home directory")?
+        .join("Library")
+        .join("LaunchAgents");
+    std::fs::create_dir_all(&agents_dir).context("Failed to create LaunchAgents directory")?;
+    let plist_path = agents_dir.join("io.worktree.runner.plist");
+    std::fs::write(&plist_path, launch_agent_plist_content(app))
+        .with_context(|| format!("Failed to write LaunchAgent plist at {}", plist_path.display()))?;
+    Ok(())
+}
+
+pub(super) fn launch_agent_plist_content(app: &std::path::Path) -> String {
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \
+         \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n\
+         <plist version=\"1.0\">\n\
+         <dict>\n\
+         \t<key>Label</key>\n\
+         \t<string>io.worktree.runner</string>\n\
+         \t<key>ProgramArguments</key>\n\
+         \t<array>\n\
+         \t\t<string>{lsregister}</string>\n\
+         \t\t<string>-f</string>\n\
+         \t\t<string>{app}</string>\n\
+         \t</array>\n\
+         \t<key>RunAtLoad</key>\n\
+         \t<true/>\n\
+         </dict>\n\
+         </plist>\n",
+        lsregister = super::LSREGISTER,
+        app = app.display(),
+    )
 }
 
 fn applescript_quoted(s: &str) -> String {

--- a/src/scheme/macos/install_tests.rs
+++ b/src/scheme/macos/install_tests.rs
@@ -14,3 +14,32 @@ fn test_applescript_quoted_backslash() {
 fn test_applescript_quoted_double_quote() {
     assert_eq!(applescript_quoted("say \"hi\""), "\"say \\\"hi\\\"\"");
 }
+#[test]
+fn test_launch_agent_plist_content_label() {
+    let app = std::path::Path::new("/Users/test/Applications/WorktreeRunner.app");
+    let content = launch_agent_plist_content(app);
+    assert!(content.contains("io.worktree.runner"));
+}
+
+#[test]
+fn test_launch_agent_plist_content_lsregister_flag() {
+    let app = std::path::Path::new("/Users/test/Applications/WorktreeRunner.app");
+    let content = launch_agent_plist_content(app);
+    assert!(content.contains("-f"));
+    assert!(content.contains("lsregister"));
+}
+
+#[test]
+fn test_launch_agent_plist_content_run_at_load() {
+    let app = std::path::Path::new("/Users/test/Applications/WorktreeRunner.app");
+    let content = launch_agent_plist_content(app);
+    assert!(content.contains("<true/>"));
+    assert!(content.contains("RunAtLoad"));
+}
+
+#[test]
+fn test_launch_agent_plist_content_app_path() {
+    let app = std::path::Path::new("/Users/test/Applications/WorktreeRunner.app");
+    let content = launch_agent_plist_content(app);
+    assert!(content.contains("/Users/test/Applications/WorktreeRunner.app"));
+}

--- a/src/scheme/macos/mod.rs
+++ b/src/scheme/macos/mod.rs
@@ -6,6 +6,10 @@ use anyhow::{Context, Result};
 
 use super::SchemeStatus;
 
+pub(super) const LSREGISTER: &str =
+    "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/\
+     LaunchServices.framework/Versions/A/Support/lsregister";
+
 pub(super) fn app_dir() -> std::path::PathBuf {
     dirs::home_dir()
         .unwrap_or_else(|| std::path::PathBuf::from("~"))
@@ -13,13 +17,19 @@ pub(super) fn app_dir() -> std::path::PathBuf {
         .join("WorktreeRunner.app")
 }
 
+fn launch_agent_plist_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| {
+        h.join("Library")
+            .join("LaunchAgents")
+            .join("io.worktree.runner.plist")
+    })
+}
+
 pub fn uninstall() -> Result<()> {
     let app = app_dir();
     if app.exists() {
         // LLVM_COV_EXCL_START
-        let lsregister = "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/\
-            LaunchServices.framework/Versions/A/Support/lsregister";
-        let _ = std::process::Command::new(lsregister)
+        let _ = std::process::Command::new(LSREGISTER)
             .args(["-u"])
             .arg(&app)
             .status();
@@ -29,6 +39,15 @@ pub fn uninstall() -> Result<()> {
         // LLVM_COV_EXCL_STOP
     } else {
         println!("Not installed — nothing to remove."); // LLVM_COV_EXCL_LINE
+    }
+    if let Some(plist) = launch_agent_plist_path() {
+        // LLVM_COV_EXCL_START
+        if plist.exists() {
+            std::fs::remove_file(&plist)
+                .with_context(|| format!("Failed to remove LaunchAgent plist at {}", plist.display()))?;
+            println!("Removed LaunchAgent {}", plist.display());
+        }
+        // LLVM_COV_EXCL_STOP
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Ad-hoc signs `WorktreeRunner.app` after `osacompile` with `codesign --sign - --force --deep` so Gatekeeper does not quarantine or evict the unsigned bundle after a reboot
- Installs `~/Library/LaunchAgents/io.worktree.runner.plist` during `worktree scheme install` to re-run `lsregister -f` at login, restoring the `worktree://` handler if Launch Services forgets it
- `worktree scheme uninstall` now also removes the LaunchAgent plist
- Extracts `LSREGISTER` path to a shared constant in `macos/mod.rs`

Closes #22

## Test plan

- [ ] `cargo test` passes (88 lib + 7 bin + 14 CLI + 20 git tests, all green)
- [ ] Run `worktree setup` on a real Mac, reboot, click a `worktree://` deep link — scheme still works
- [ ] Run `worktree scheme uninstall` — confirm `~/Library/LaunchAgents/io.worktree.runner.plist` is removed
- [ ] `worktree scheme status` reports installed before and not-installed after uninstall

🤖 Generated with [Claude Code](https://claude.com/claude-code)