### PR TITLE
chore(lint): enable clippy::dbg_macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,5 @@ nursery = { level = "deny", priority = -1 }
 cargo = { level = "deny", priority = -1 }
 # Cannot control transitive dependency version conflicts
 multiple_crate_versions = "allow"
+# Forbid leftover `dbg!` debugging macros from reaching production
+dbg_macro = "deny"


### PR DESCRIPTION
## What

Enable the `clippy::dbg_macro` restriction lint (`deny`) in the `[lints.clippy]` table.

```toml
# Forbid leftover `dbg!` debugging macros from reaching production
dbg_macro = "deny"
```

## Why

`dbg!()` is a debugging aid that prints to stderr and should never ship. This lint prevents accidental debug artifacts from being committed, keeping stderr output intentional. It lives in the `restriction` group — not covered by the `pedantic`/`nursery`/`cargo` groups already enabled here — so it's a genuinely new check and fits the repo's strict, deny-by-default posture.

## Impact

- **0** violations across lib, binary, and all test targets — zero-churn config change.
- `cargo clippy --all-targets`, `cargo build`, and `cargo test` all pass locally.

Closes #86