### PR TITLE
chore(lint): enable clippy::todo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,5 @@ cargo = { level = "deny", priority = -1 }
 multiple_crate_versions = "allow"
 # Forbid leftover `dbg!` debugging macros from reaching production
 dbg_macro = "deny"
+# Forbid leftover `todo!` placeholders from reaching production
+todo = "deny"

--- a/src/commands/open/hook_build_tests.rs
+++ b/src/commands/open/hook_build_tests.rs
@@ -71,8 +71,6 @@ fn test_run_auto_prune_with_ttl_no_expired() {
     let mut config = Config::default();
     config.workspace.auto_prune = true;
     // 1000-year TTL: no real registry entry can be this old, so nothing is pruned
-    config.workspace.ttl = Some(Ttl::new(std::time::Duration::from_secs(
-        1_000 * 365 * 24 * 3600,
-    )));
+    config.workspace.ttl = Some(Ttl::new(std::time::Duration::from_hours(1_000 * 365 * 24)));
     run_auto_prune(&config);
 }

--- a/src/git/branch.rs
+++ b/src/git/branch.rs
@@ -73,6 +73,5 @@ pub fn branch_exists_remote(bare: &Path, branch: &str) -> bool {
             &format!("refs/remotes/origin/{branch}"),
         ])
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .is_ok_and(|o| o.status.success())
 }

--- a/src/git/local_branch.rs
+++ b/src/git/local_branch.rs
@@ -49,6 +49,5 @@ pub fn branch_exists_local(repo: &Path, branch: &str) -> bool {
         .arg(repo)
         .args(["rev-parse", "--verify", &format!("refs/heads/{branch}")])
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .is_ok_and(|o| o.status.success())
 }

--- a/src/issue/paths.rs
+++ b/src/issue/paths.rs
@@ -21,7 +21,7 @@ impl IssueRef {
     /// Panics if the home directory cannot be determined.
     #[must_use]
     pub fn bare_clone_path(&self) -> PathBuf {
-        let temp = Config::load().map(|c| c.workspace.temp).unwrap_or(false);
+        let temp = Config::load().is_ok_and(|c| c.workspace.temp);
         self.bare_clone_path_rooted(temp)
     }
 

--- a/src/ttl/mod.rs
+++ b/src/ttl/mod.rs
@@ -44,8 +44,7 @@ impl std::str::FromStr for Ttl {
 #[must_use]
 pub fn is_expired(record: &WorkspaceRecord, ttl: &Ttl, now: SystemTime) -> bool {
     now.duration_since(record.created_at)
-        .map(|age| age >= ttl.0)
-        .unwrap_or(false)
+        .is_ok_and(|age| age >= ttl.0)
 }
 
 /// Returns workspaces that are both present on disk and have exceeded the TTL.

--- a/src/ttl/prune_tests.rs
+++ b/src/ttl/prune_tests.rs
@@ -16,7 +16,7 @@ fn record(path: PathBuf, created_at: SystemTime) -> WorkspaceRecord {
 #[test]
 fn test_prune_returns_expired_with_existing_path() {
     let dir = tempfile::tempdir().unwrap();
-    let ttl = Ttl::new(Duration::from_secs(60));
+    let ttl = Ttl::new(Duration::from_mins(1));
     let records = vec![record(dir.path().to_path_buf(), past(120))];
     let expired = prune(&records, &ttl, SystemTime::now());
     assert_eq!(expired.len(), 1);
@@ -25,7 +25,7 @@ fn test_prune_returns_expired_with_existing_path() {
 
 #[test]
 fn test_prune_skips_missing_paths() {
-    let ttl = Ttl::new(Duration::from_secs(60));
+    let ttl = Ttl::new(Duration::from_mins(1));
     let records = vec![record(PathBuf::from("/nonexistent/path/xyz"), past(120))];
     assert!(prune(&records, &ttl, SystemTime::now()).is_empty());
 }
@@ -33,7 +33,7 @@ fn test_prune_skips_missing_paths() {
 #[test]
 fn test_prune_skips_unexpired() {
     let dir = tempfile::tempdir().unwrap();
-    let ttl = Ttl::new(Duration::from_secs(3600));
+    let ttl = Ttl::new(Duration::from_hours(1));
     let records = vec![record(dir.path().to_path_buf(), past(60))];
     assert!(prune(&records, &ttl, SystemTime::now()).is_empty());
 }
@@ -42,7 +42,7 @@ fn test_prune_skips_unexpired() {
 fn test_prune_mixed_records() {
     let expired_dir = tempfile::tempdir().unwrap();
     let fresh_dir = tempfile::tempdir().unwrap();
-    let ttl = Ttl::new(Duration::from_secs(600));
+    let ttl = Ttl::new(Duration::from_mins(10));
     let records = vec![
         record(expired_dir.path().to_path_buf(), past(1200)),
         record(fresh_dir.path().to_path_buf(), past(60)),

--- a/src/ttl/serde_tests.rs
+++ b/src/ttl/serde_tests.rs
@@ -17,7 +17,7 @@ struct RecordHelper {
 
 #[test]
 fn test_ttl_serde_round_trip() {
-    let original = Ttl::new(Duration::from_secs(7 * 24 * 3600));
+    let original = Ttl::new(Duration::from_hours(7 * 24));
     let s = toml::to_string(&TtlHelper { ttl: original }).unwrap();
     let parsed: TtlHelper = toml::from_str(&s).unwrap();
     assert_eq!(parsed.ttl.duration(), original.duration());
@@ -44,7 +44,7 @@ fn test_workspace_registry_serde_with_entries() {
 #[test]
 fn test_workspace_record_serde_round_trip() {
     let created_at = SystemTime::now()
-        .checked_sub(Duration::from_secs(3600))
+        .checked_sub(Duration::from_hours(1))
         .unwrap();
     let h = RecordHelper {
         workspace: vec![WorkspaceRecord {

--- a/src/ttl/ttl_tests.rs
+++ b/src/ttl/ttl_tests.rs
@@ -19,13 +19,13 @@ fn future(secs: u64) -> SystemTime {
 
 #[test]
 fn test_ttl_new_and_duration() {
-    let d = Duration::from_secs(3600);
+    let d = Duration::from_hours(1);
     assert_eq!(Ttl::new(d).duration(), d);
 }
 
 #[test]
 fn test_ttl_display_round_trips() {
-    let ttl = Ttl::new(Duration::from_secs(7 * 24 * 3600));
+    let ttl = Ttl::new(Duration::from_hours(7 * 24));
     let parsed: Ttl = ttl.to_string().parse().unwrap();
     assert_eq!(parsed.duration(), ttl.duration());
 }
@@ -33,7 +33,7 @@ fn test_ttl_display_round_trips() {
 #[test]
 fn test_ttl_parse_valid() {
     let ttl: Ttl = "1day".parse().unwrap();
-    assert_eq!(ttl.duration(), Duration::from_secs(86_400));
+    assert_eq!(ttl.duration(), Duration::from_hours(24));
 }
 
 #[test]
@@ -45,7 +45,7 @@ fn test_ttl_parse_invalid() {
 
 #[test]
 fn test_is_expired_when_age_exceeds_ttl() {
-    let ttl = Ttl::new(Duration::from_secs(60));
+    let ttl = Ttl::new(Duration::from_mins(1));
     let r = WorkspaceRecord {
         path: PathBuf::new(),
         created_at: past(120),
@@ -55,7 +55,7 @@ fn test_is_expired_when_age_exceeds_ttl() {
 
 #[test]
 fn test_is_not_expired_when_young() {
-    let ttl = Ttl::new(Duration::from_secs(3600));
+    let ttl = Ttl::new(Duration::from_hours(1));
     let r = WorkspaceRecord {
         path: PathBuf::new(),
         created_at: past(60),
@@ -65,7 +65,7 @@ fn test_is_not_expired_when_young() {
 
 #[test]
 fn test_is_not_expired_when_created_in_future() {
-    let ttl = Ttl::new(Duration::from_secs(60));
+    let ttl = Ttl::new(Duration::from_mins(1));
     let r = WorkspaceRecord {
         path: PathBuf::new(),
         created_at: future(30),


### PR DESCRIPTION
## Summary

Enables `clippy::todo = "deny"` in `[lints.clippy]`, preventing `todo!()` placeholders from reaching production code. This follows the same pattern as the existing `dbg_macro = "deny"` lint — both catch development-only constructs that cause runtime panics if accidentally shipped.

Also fixes pre-existing `pedantic` violations so that `cargo clippy --all-targets` passes cleanly:
- **4 `map_unwrap_or`**: `.map(f).unwrap_or(false)` → `.is_ok_and(f)`
- **12 `duration_suboptimal_units`** in test code: `Duration::from_secs(N)` → `from_hours`/`from_mins` equivalents

Closes #89

---

> This pull request was opened by the **Clippy lint improvements → issue + PR (Rust repos)** routine of [moadim](https://moadim.io). @tupe12334