### PR TITLE
chore(lint): enable clippy::panic_in_result_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,6 @@ panic = "deny"
 # (invariants the caller already checked, intentionally documented panics)
 # carry a localized `#[allow]`; everywhere else propagate via `anyhow::Result`.
 expect_used = "deny"
+# Prevent panic!() inside Result/Option-returning functions; failures must be
+# returned as Err(_)/None so callers can handle them rather than crashing.
+panic_in_result_fn = "deny"


### PR DESCRIPTION
## Summary
- Enable `clippy::panic_in_result_fn` (restriction) in `Cargo.toml`'s `[lints.clippy]` table, following the same style/comment convention as the existing entries.
- No source changes needed — the crate already has zero violations of this lint.

## Test plan
- [x] `cargo build --all-targets` — passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — passes, no warnings
- [x] `cargo test` — 22 unit tests + 6 snapshot tests pass
- [x] `cargo fmt --check` — passes

Closes #95

---
This pull request was opened by the Open issues → fix PRs (owned repos + my orgs) routine of moadim. @tupe12334